### PR TITLE
Unused slots of the array are zeroed.

### DIFF
--- a/efs/directory.go
+++ b/efs/directory.go
@@ -28,6 +28,9 @@ func (d Directory) Entries() []DirectoryEntry {
 	for i := range entries {
 		// The "slots" at the low indexes of Data tell us where the
 		// "entries" in the high indexes are
+		if (d.Data[i] == 0) {
+		  continue
+		}
 		offset := (int(d.Data[i]) << 1) - DirectoryHeaderOffset
 
 		r := bytes.NewReader(d.Data[offset:])


### PR DESCRIPTION
See http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/fs/efs/efs_dir.h?rev=1.2&content-type=text/x-cvsweb-markup